### PR TITLE
Soop의 Streamer Channel의 station 데이터 API 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ const streamerId = "cotton1217"
 const client = new SoopClient();
 
 // 라이브 세부정보
-const data = await client.live.detail(streamerId);
-console.log(data)
+const liveDetail = await client.live.detail(streamerId);
+console.log(liveDetail)
+
+// 채널 정보
+const stationInfo = await client.channel.station(streamerId);
+console.log(stationInfo)
 
 const soopChat = client.chat({
     streamerId: streamerId

--- a/example.ts
+++ b/example.ts
@@ -1,12 +1,16 @@
 import { SoopClient } from "./src"
 
 (async function () {
-    const streamerId = "cotton1217"
+    const streamerId = "jingburger1"
     const client = new SoopClient();
 
     // 라이브 세부정보
-    const data = await client.live.detail(streamerId);
-    console.log(data)
+    const liveDetail = await client.live.detail(streamerId);
+    console.log(liveDetail)
+
+    // 채널 정보
+    const stationInfo = await client.channel.station(streamerId);
+    console.log(stationInfo)
 
     const soopChat = client.chat({
         streamerId: streamerId

--- a/src/api/channel.ts
+++ b/src/api/channel.ts
@@ -1,0 +1,178 @@
+import {SoopClient} from "../client"
+import {DEFAULT_BASE_URLS} from "../const"
+
+interface StationInfo {
+    profile_image: string;
+    station: Station;
+    broad: Broad;
+    starballoon_top: StarBalloonTop[];
+    sticker_top: StickerTop[];
+    subscription: Subscription;
+    is_best_bj: boolean;
+    is_partner_bj: boolean;
+    is_ppv_bj: boolean;
+    is_af_supporters_bj: boolean;
+    is_shopfreeca_bj: boolean;
+    is_favorite: boolean;
+    is_subscription: boolean;
+    is_owner: boolean;
+    is_manager: boolean;
+    is_notice: boolean;
+    is_adsence: boolean;
+    is_mobile_push: boolean;
+    subscribe_visible: string;
+    country: string;
+    current_timestamp: string;
+}
+
+interface Station {
+    display: Display;
+    groups: Group[];
+    menus: Menu[];
+    upd: Upd;
+    vods: Vod[];
+    broad_start: string;
+    grade: number;
+    jointime: string;
+    station_name: string;
+    station_no: number;
+    station_title: string;
+    total_broad_time: number;
+    user_id: string;
+    user_nick: string;
+    active_no: number;
+}
+
+interface Display {
+    main_type: string;
+    title_type: string;
+    title_text: string;
+    profile_text: string;
+    skin_type: number;
+    skin_no: number;
+    title_skin_image: string;
+}
+
+interface Group {
+    idx: number;
+    group_no: number;
+    priority: number;
+    info: {
+        group_name: string;
+        group_class_name: string;
+        group_background_color: string;
+    };
+}
+
+interface Menu {
+    bbs_no: number;
+    station_no: number;
+    auth_no: number;
+    w_auth_no: number;
+    display_type: number;
+    rnum: number;
+    line: number;
+    indention: number;
+    name: string;
+    name_font: number;
+    main_view_yn: number;
+    view_type: number;
+}
+
+interface Upd {
+    station_no: number;
+    user_id: string;
+    asp_code: number;
+    fan_cnt: number;
+    today0_visit_cnt: number;
+    today1_visit_cnt: number;
+    total_visit_cnt: number;
+    today0_ok_cnt: number;
+    today1_ok_cnt: number;
+    today0_fav_cnt: number;
+    today1_fav_cnt: number;
+    total_ok_cnt: number;
+    total_view_cnt: number;
+}
+
+interface Vod {
+    bbs_no: number;
+    station_no: number;
+    auth_no: number;
+    w_auth_no: number;
+    display_type: number;
+    rnum: number;
+    line: number;
+    indention: number;
+    name: string;
+    name_font: number;
+    main_view_yn: number;
+    view_type: number;
+}
+
+interface Broad {
+    user_id: string;
+    broad_no: number;
+    broad_title: string;
+    current_sum_viewer: number;
+    broad_grade: number;
+    is_password: boolean;
+}
+
+interface StarBalloonTop {
+    user_id: string;
+    user_nick: string;
+    profile_image: string;
+}
+
+interface StickerTop {
+    user_id: string;
+    user_nick: string;
+    profile_image: string;
+}
+
+interface Subscription {
+    total: number;
+    tier1: number;
+    tier2: number;
+}
+
+export class SoopChannel {
+    private client: SoopClient
+
+    constructor(client: SoopClient) {
+        this.client = client
+    }
+
+    async station(streamerId: string, baseUrl: string = DEFAULT_BASE_URLS.soopChannelBaseUrl): Promise<StationInfo> {
+        return this.client.fetch(`${baseUrl}/api/${streamerId}/station`, {
+            method: "GET",
+        })
+            .then(response => response.json())
+            .then(data => {
+                return {
+                    profile_image: data["profile_image"],
+                    station: data["station"],
+                    broad: data["broad"],
+                    starballoon_top: data["starballoon_top"],
+                    sticker_top: data["sticker_top"],
+                    subscription: data["subscription"],
+                    is_best_bj: data["is_best_bj"],
+                    is_partner_bj: data["is_partner_bj"],
+                    is_ppv_bj: data["is_ppv_bj"],
+                    is_af_supporters_bj: data["is_af_supporters_bj"],
+                    is_shopfreeca_bj: data["is_shopfreeca_bj"],
+                    is_favorite: data["is_favorite"],
+                    is_subscription: data["is_subscription"],
+                    is_owner: data["is_owner"],
+                    is_manager: data["is_manager"],
+                    is_notice: data["is_notice"],
+                    is_adsence: data["is_adsence"],
+                    is_mobile_push: data["is_mobile_push"],
+                    subscribe_visible: data["subscribe_visible"],
+                    country: data["country"],
+                    current_timestamp: data["current_timestamp"]
+                };
+            })
+    }
+}

--- a/src/api/live.ts
+++ b/src/api/live.ts
@@ -1,4 +1,5 @@
 import {SoopClient} from "../client"
+import {DEFAULT_BASE_URLS} from "../const"
 
 export interface LiveDetail {
     CHANNEL: {
@@ -124,7 +125,11 @@ export class SoopLive {
         this.client = client
     }
 
-    async detail(streamerId: string, options: LiveDetailOptions = DEFAULT_REQUEST_BODY_FOR_LIVE_STATUS): Promise<LiveDetail> {
+    async detail(
+        streamerId: string,
+        options: LiveDetailOptions = DEFAULT_REQUEST_BODY_FOR_LIVE_STATUS,
+        baseUrl: string = DEFAULT_BASE_URLS.soopLiveBaseUrl
+    ): Promise<LiveDetail> {
         const body = {
             bid: streamerId,
             ...(options || {})
@@ -135,7 +140,7 @@ export class SoopLive {
                 return acc;
             }, {} as Record<string, string>)
         );
-        return this.client.fetch(`/afreeca/player_live_api.php?bjid=${streamerId}`, {
+        return this.client.fetch(`${baseUrl}/afreeca/player_live_api.php?bjid=${streamerId}`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/x-www-form-urlencoded",

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,10 +3,12 @@ import {SoopChatFunc, SoopClientOptions} from "./types"
 import {DEFAULT_BASE_URLS, DEFAULT_USER_AGENT} from "./const"
 import { SoopChatOptions } from "./chat/types"
 import { SoopChat } from "./chat"
+import {SoopChannel} from "./api/channel"
 
 export class SoopClient {
     readonly options: SoopClientOptions
     live = new SoopLive(this)
+    channel = new SoopChannel(this)
 
     constructor(options: SoopClientOptions = {}) {
         options.baseUrls = options.baseUrls || DEFAULT_BASE_URLS
@@ -25,18 +27,13 @@ export class SoopClient {
         }
     }
 
-    fetch(pathOrUrl: string, options?: RequestInit): Promise<Response> {
+    fetch(url: string, options?: RequestInit): Promise<Response> {
         const headers = {
             "User-Agent": this.options.userAgent,
             ...(options?.headers || {})
         }
 
-        if ((pathOrUrl.startsWith("/") || pathOrUrl.startsWith("?"))
-             && !pathOrUrl.startsWith(this.options.baseUrls.soopLiveBaseUrl)) {
-            pathOrUrl = `${this.options.baseUrls.soopLiveBaseUrl}${pathOrUrl}`
-        }
-
-        return fetch(pathOrUrl, {
+        return fetch(url, {
             headers: headers,
             ...options
         })

--- a/src/const.ts
+++ b/src/const.ts
@@ -2,6 +2,7 @@ import {SoopAPIBaseUrls} from "./types"
 
 export const DEFAULT_BASE_URLS: SoopAPIBaseUrls = {
     soopLiveBaseUrl: 'https://live.sooplive.co.kr',
+    soopChannelBaseUrl: 'https://chapi.sooplive.co.kr'
 }
 
 export const DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2049.0 Safari/537.36"

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import {SoopChat, SoopChatOptions} from "./chat"
 
 export interface SoopAPIBaseUrls {
     soopLiveBaseUrl?: string
-    soopBridgeBaseUrl?: string
+    soopChannelBaseUrl?: string
 }
 
 export interface SoopClientOptions {


### PR DESCRIPTION
Soop의 Streamer Channel의 station 데이터 API 구현하였음

사용할 수 있는 데이터는 아래 URL로 접속해보면 가능함
streamerId의 경우 아래 예시와 같이 붙여넣고 확인

ex) 우왁굳: ecvhao, 봉준: khm11903, 김민교: phonics1

- URL: https://chapi.sooplive.co.kr/api/${streamerId}/station