### PR TITLE
채팅방 입장 시 사용자 ID 송신하기

### DIFF
--- a/example.ts
+++ b/example.ts
@@ -6,7 +6,7 @@ import { SoopClient } from "./src"
 
     // 라이브 세부정보
     const liveDetail = await client.live.detail(streamerId);
-    console.log(liveDetail)
+    console.log(liveDetail.CHANNEL.VIEWPRESET)
 
     // 채널 정보
     const stationInfo = await client.channel.station(streamerId);
@@ -15,12 +15,13 @@ import { SoopClient } from "./src"
     // 로그인 (쿠키 반환)
     // 아래와 같이 숲 ID, PASSWORD 문자열 입력 가능 (그대로 VCS 업로드 시 공개된 공간에 노출될 수 있음)
     // const cookie = await client.auth.signIn("USERID", "PASSWORD");
-    const cookie = await client.auth.signIn(process.env.USERID, process.env.PASSWORD);
+    const { cookie, uuid } = await client.auth.signIn(process.env.USERID, process.env.PASSWORD);
     console.log(cookie)
+    console.log(uuid)
 
     const soopChat = client.chat({
         streamerId: streamerId,
-        cookie: cookie // sendChat 기능을 사용하고 싶을 경우 세팅
+        login: { userId: process.env.USERID, password: process.env.PASSWORD } // sendChat 기능을 사용하고 싶을 경우 세팅
     })
 
     // 연결 성공
@@ -135,8 +136,8 @@ import { SoopClient } from "./src"
     // 채팅 송신
     // 바로 채팅 송신 시 채팅방 연결까지 대기 후 송신
     // 연속으로 채팅 송신 시 벤 및 송신 실패할 수 있으므로 송신 전 대기 시간 설정 필요
-    await soopChat.sendChat("ㅋㅋㅋㅋ");
+    await soopChat.sendChat("오오");
     setInterval(async () => {
-        await soopChat.sendChat("ㅋㅋㅋㅋ");
+        await soopChat.sendChat("신기하다");
     }, 5000)
 })();

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,9 +1,9 @@
 import {SoopClient} from "../client"
 import {DEFAULT_BASE_URLS} from "../const"
 
-interface Auth {
-    RESULT: number,
-    notChangePwd: number
+export interface Auth {
+    uuid: string,
+    cookie: string
 }
 
 export class SoopAuth {
@@ -17,7 +17,7 @@ export class SoopAuth {
         userId: string,
         password: string,
         baseUrl: string = DEFAULT_BASE_URLS.soopAuthBaseUrl
-    ): Promise<string> {
+    ): Promise<Auth> {
         const formData = new FormData();
         formData.append("szWork", "login");
         formData.append("szType", "json");
@@ -31,8 +31,9 @@ export class SoopAuth {
             .then(response => {
                 const setCookieHeader = response.headers.get('set-cookie');
                 const authTicketMatch = setCookieHeader?.match(/AuthTicket=([^;]+)/);
-                if (authTicketMatch) {
-                    return authTicketMatch[1];
+                const uuid = setCookieHeader?.match(/_au=([^;]+)/);
+                if (authTicketMatch && uuid) {
+                    return { uuid: uuid[1], cookie: authTicketMatch[1] };
                 } else {
                     return null;
                 }

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -1,9 +1,9 @@
-import {SoopAPIBaseUrls} from "../types"
+import {SoopAPIBaseUrls, SoopLoginOptions} from "../types"
 import {SoopClient} from "../client"
 
 export interface SoopChatOptions {
     streamerId: string
-    cookie?: string
+    login?: SoopLoginOptions
     baseUrls?: SoopAPIBaseUrls
 }
 
@@ -14,6 +14,9 @@ export interface SoopChatOptionsWithClient extends SoopChatOptions {
 export enum ChatDelimiter {
     STARTER = "\x1b\t",
     SEPARATOR = "\x0c",
+    ELEMENT_START = "\x11",
+    ELEMENT_END = "\x12",
+    SPACE = "\x06"
 }
 
 export enum ChatType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,11 @@ export interface SoopClientOptions {
     userAgent?: string
 }
 
+export interface SoopLoginOptions {
+    userId?: string,
+    password?: string
+}
+
 export type SoopChatFunc = {
     (options: SoopChatOptions): SoopChat
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "compilerOptions": {
         "lib": [
-            "ES2016",
+            "ESNext",
         ],
         "outDir": "./dist/",
-        "target": "ES2016",
+        "target": "ESNext",
         "esModuleInterop": true,
         "declaration": true,
         "module": "CommonJS",


### PR DESCRIPTION
채팅방 입장 시 사용자 ID를 송신하도록 로직을 추가하였습니다.

그러나 채팅방에 사용자 세부정보(팬클럽, 구독)를 직접 확인할 수 없었습니다.

숲 스트리머에게 도네이션을 보낸 적이 없어 위와 같은 세부정보가 있는 계정이 없기 때문입니다.

직접 사용 후 확인해봐야할 것 같습니다.

ps. #6 (유저 속성 불러오지 못함) 해당 이슈를 위해 던진 PR입니다.